### PR TITLE
Fix dependencies with the new expressjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "dependencies": {
     "express": "latest",
+    "compression": "latest",
+    "body-parser": "latest",
+    "util": "latest",
     "underscore": "latest",
     "keepass.io": "latest",
     "q": "latest"

--- a/server.js
+++ b/server.js
@@ -14,8 +14,8 @@
   };
 
   var app = express();
-  app.use(express.compress());
-  app.use(express.bodyParser());
+  app.use(require("compression")());
+  app.use(require("body-parser")());
 //  app.use(express.basicAuth(function (user, pass, callback) {
 //    var isValid = (user === basicAuth.username && pass === basicAuth.password);
 //    callback(null /* error */, isValid);


### PR DESCRIPTION
Fix the error at start by adding dependencies :

```
Error: Most middleware (like compress) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.
```
